### PR TITLE
create test runner specific Test Base classes and Watchers

### DIFF
--- a/selenium-examples/junit/src/test/java/com/yourcompany/Tests/JUnitBase.java
+++ b/selenium-examples/junit/src/test/java/com/yourcompany/Tests/JUnitBase.java
@@ -1,0 +1,49 @@
+package com.yourcompany.Tests;
+
+import com.saucelabs.saucebindings.SauceOptions;
+import com.saucelabs.saucebindings.SauceSession;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.rules.TestName;
+import org.openqa.selenium.WebDriver;
+
+@Ignore
+public abstract class JUnitBase {
+    protected SauceOptions options;
+    protected SauceSession session;
+    protected WebDriver driver;
+
+    @Rule
+    public SauceTestWatcher testWatcher = new SauceTestWatcher();
+
+    @Rule
+    public TestName name = new TestName() {
+        public String getMethodName() {
+            return String.format("%s", super.getMethodName());
+        }
+    };
+
+    public String getMethodName() {
+        return name.getMethodName();
+    }
+
+    public void createOptions() {
+        options = new SauceOptions();
+        options.setName(getMethodName());
+    }
+
+    public void updateOptions() {
+        // implement in subclass
+    }
+
+    @Before
+    public void setUp() {
+        createOptions();
+        updateOptions();
+        session = new SauceSession(options);
+        testWatcher.setSession(session);
+
+        driver = session.start();
+    }
+}

--- a/selenium-examples/junit/src/test/java/com/yourcompany/Tests/SauceTestWatcher.java
+++ b/selenium-examples/junit/src/test/java/com/yourcompany/Tests/SauceTestWatcher.java
@@ -18,4 +18,9 @@ public class SauceTestWatcher extends TestWatcher {
     protected void failed(Description description) {
         sauceSession.stop("failed");
     }
+
+    protected void finished(Description description) {
+        // Implement an `isFinished()` method and use API to ensure that session is stopped
+    }
+
 }

--- a/selenium-examples/junit/src/test/java/com/yourcompany/Tests/TestBase.java
+++ b/selenium-examples/junit/src/test/java/com/yourcompany/Tests/TestBase.java
@@ -1,35 +1,12 @@
 package com.yourcompany.Tests;
 
 import com.saucelabs.saucebindings.Browser;
-import com.saucelabs.saucebindings.SauceOptions;
 import com.saucelabs.saucebindings.SaucePlatform;
-import com.saucelabs.saucebindings.SauceSession;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.rules.TestName;
-import org.openqa.selenium.WebDriver;
 
-@Ignore
-public class TestBase {
-    public SauceSession session;
-    protected WebDriver driver;
+public class TestBase extends JUnitBase {
 
-    @Rule
-    public SauceTestWatcher testWatcher = new SauceTestWatcher();
-
-    @Rule
-    public TestName name = new TestName() {
-        public String getMethodName() {
-            return String.format("%s", super.getMethodName());
-        }
-    };
-
-    @Before
-    public void setUp() {
-        SauceOptions options = new SauceOptions();
-        options.setName(name.getMethodName());
-
+    @Override
+    public void updateOptions() {
         if (System.getenv("START_TIME") != null) {
             options.setBuild("Build Time: " + System.getenv("START_TIME"));
         }
@@ -66,10 +43,5 @@ public class TestBase {
                 // accept Sauce defaults
                 break;
         }
-
-        session = new SauceSession(options);
-        testWatcher.setSession(session);
-
-        driver = session.start();
     }
 }

--- a/selenium-examples/testng/se_testng.iml
+++ b/selenium-examples/testng/se_testng.iml
@@ -1,12 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_9">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.testng:testng:6.10" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.beust:jcommander:1.48" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.seleniumhq.selenium:selenium-java:3.141.59" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.seleniumhq.selenium:selenium-api:3.141.59" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.seleniumhq.selenium:selenium-chrome-driver:3.141.59" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.seleniumhq.selenium:selenium-edge-driver:3.141.59" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.seleniumhq.selenium:selenium-firefox-driver:3.141.59" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.seleniumhq.selenium:selenium-ie-driver:3.141.59" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.seleniumhq.selenium:selenium-opera-driver:3.141.59" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.seleniumhq.selenium:selenium-remote-driver:3.141.59" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.seleniumhq.selenium:selenium-safari-driver:3.141.59" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.seleniumhq.selenium:selenium-support:3.141.59" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy:1.8.15" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.commons:commons-exec:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.google.guava:guava:25.0-jre" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.google.code.findbugs:jsr305:1.3.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.checkerframework:checker-compat-qual:2.0.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.google.errorprone:error_prone_annotations:2.1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.google.j2objc:j2objc-annotations:1.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.codehaus.mojo:animal-sniffer-annotations:1.14" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.squareup.okhttp3:okhttp:3.11.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.squareup.okio:okio:1.14.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-lang:commons-lang:2.6" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.saucelabs:sauce_testng:2.1.23" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.saucelabs:sauce_java_common:2.1.23" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.googlecode.json-simple:json-simple:1.1.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.saucelabs:saucerest:1.0.32" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.httpcomponents:httpclient:4.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.httpcomponents:httpcore:4.4.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-logging:commons-logging:1.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.json:json:20090211" level="project" />
+    <orderEntry type="library" name="Maven: com.saucelabs:sauce_bindings:1.0-beta-5" level="project" />
+    <orderEntry type="library" name="Maven: org.projectlombok:lombok:1.18.10" level="project" />
+    <orderEntry type="library" name="Maven: junit:junit:4.12" level="project" />
   </component>
 </module>

--- a/selenium-examples/testng/src/test/java/com/yourcompany/Tests/TestBase.java
+++ b/selenium-examples/testng/src/test/java/com/yourcompany/Tests/TestBase.java
@@ -3,35 +3,13 @@ package com.yourcompany.Tests;
 import com.saucelabs.saucebindings.Browser;
 import com.saucelabs.saucebindings.SauceOptions;
 import com.saucelabs.saucebindings.SaucePlatform;
-import com.saucelabs.saucebindings.SauceSession;
-import org.openqa.selenium.WebDriver;
-import org.testng.ITestResult;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 
-import java.lang.reflect.Method;
+public class TestBase  extends TestNGBase {
 
-public class TestBase  {
-
-    protected static ThreadLocal<SauceSession> session = new ThreadLocal<>();
-    protected static ThreadLocal<SauceOptions> options = new ThreadLocal<>();
-
-    public SauceSession getSession() {
-        return session.get();
-    }
-
-    public WebDriver getDriver() {
-        return getSession().getDriver();
-    }
-
-    @BeforeMethod
-    public void setup (Method method) {
-        options.set(new SauceOptions());
-        options.get().setName(method.getName());
-
+    @Override
+    public SauceOptions updateOptions(SauceOptions options) {
         if (System.getenv("START_TIME") != null) {
-            options.get().setBuild("Build Time: " + System.getenv("START_TIME"));
+            options.setBuild("Build Time: " + System.getenv("START_TIME"));
         }
 
         String platform;
@@ -43,42 +21,30 @@ public class TestBase  {
 
         switch(platform) {
             case "windows_10_edge":
-                options.get().setPlatformName(SaucePlatform.WINDOWS_10);
-                options.get().setBrowserName(Browser.EDGE);
+                options.setPlatformName(SaucePlatform.WINDOWS_10);
+                options.setBrowserName(Browser.EDGE);
                 break;
             case "mac_sierra_chrome":
-                options.get().setPlatformName(SaucePlatform.MAC_SIERRA);
-                options.get().setBrowserName(Browser.CHROME);
+                options.setPlatformName(SaucePlatform.MAC_SIERRA);
+                options.setBrowserName(Browser.CHROME);
                 break;
             case "windows_8_ff":
-                options.get().setPlatformName(SaucePlatform.WINDOWS_8);
-                options.get().setBrowserName(Browser.FIREFOX);
+                options.setPlatformName(SaucePlatform.WINDOWS_8);
+                options.setBrowserName(Browser.FIREFOX);
                 break;
             case "windows_8_1_ie":
-                options.get().setPlatformName(SaucePlatform.WINDOWS_8_1);
-                options.get().setBrowserName(Browser.INTERNET_EXPLORER);
+                options.setPlatformName(SaucePlatform.WINDOWS_8_1);
+                options.setBrowserName(Browser.INTERNET_EXPLORER);
                 break;
             case "mac_mojave_safari":
-                options.get().setPlatformName(SaucePlatform.MAC_MOJAVE);
-                options.get().setBrowserName(Browser.SAFARI);
+                options.setPlatformName(SaucePlatform.MAC_MOJAVE);
+                options.setBrowserName(Browser.SAFARI);
                 break;
             default:
                 // accept Sauce defaults
                 break;
         }
 
-        session.set(new SauceSession(options.get()));
-
-        getSession().start();
-    }
-
-    @AfterMethod
-    public void tearDown(ITestResult result) {
-        getSession().stop(result.isSuccess());
-    }
-
-    @AfterClass
-    void terminate () {
-        session.remove();
+        return options;
     }
 }

--- a/selenium-examples/testng/src/test/java/com/yourcompany/Tests/TestNGBase.java
+++ b/selenium-examples/testng/src/test/java/com/yourcompany/Tests/TestNGBase.java
@@ -1,0 +1,57 @@
+package com.yourcompany.Tests;
+
+import com.saucelabs.saucebindings.SauceOptions;
+import com.saucelabs.saucebindings.SauceSession;
+import org.openqa.selenium.WebDriver;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+import java.lang.reflect.Method;
+
+public class TestNGBase {
+
+    protected static ThreadLocal<SauceSession> sessionThreadLocal = new ThreadLocal<>();
+    protected static ThreadLocal<SauceOptions> optionsThreadLocal = new ThreadLocal<>();
+
+    public SauceSession getSession() {
+        return sessionThreadLocal.get();
+    }
+
+    public SauceOptions getOptions() {
+        return optionsThreadLocal.get();
+    }
+
+    public WebDriver getDriver() {
+        return getSession().getDriver();
+    }
+
+    public void createOptions(Method method) {
+        optionsThreadLocal.set(new SauceOptions());
+        optionsThreadLocal.get().setName(method.getName());
+    }
+
+    public SauceOptions updateOptions(SauceOptions options) {
+        return options;
+    }
+
+    @BeforeMethod
+    public void setup (Method method) {
+        createOptions(method);
+        SauceOptions options = updateOptions(getOptions());
+        sessionThreadLocal.set(new SauceSession(options));
+
+        sessionThreadLocal.get().start();
+    }
+
+    @AfterMethod
+    public void tearDown(ITestResult result) {
+        getSession().stop(result.isSuccess());
+    }
+
+    @AfterClass
+    void terminate () {
+        sessionThreadLocal.remove();
+    }
+}


### PR DESCRIPTION
This PR is a stepping stone for pulling out some of these files and creating new jar files. Once implemented, they'll be deleted from this project and imported as a dependency.

For Sauce Bindings 1.2(?) we want to be able to create Test Runner specific helper classes.
One benefit is we can auto generate test name if it isn't already defined.
Another benefit is just less boiler plate code for the user.

My goal is to create
`sauce-bindings-junit.jar` with `JUnitBase.java` and `SauceTestWatcher`
and
`sauce-bindings-testng.jar` with `TestNGBase.java`

You can take a look at the two `TestBase.java` files below to see what would be required by end users with this approach.
Also, note that if you just want defaults your tests can extend `JUnitBase` or `TestNGBase` directly.

What do you think of this approach?