### PR TITLE
update the code in w3c examples

### DIFF
--- a/w3c-examples/w3c-junit5/src/test/java/JUnit5W3CChromeTest.java
+++ b/w3c-examples/w3c-junit5/src/test/java/JUnit5W3CChromeTest.java
@@ -3,7 +3,6 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
@@ -33,38 +32,42 @@ public class JUnit5W3CChromeTest {
         String accessKey = System.getenv("SAUCE_ACCESS_KEY");
         String methodName = testInfo.getDisplayName();
 
-        /** ChomeOptions allows us to set browser-specific behavior such as profile settings, headless capabilities, insecure tls certs,
-         and in this example--the W3C protocol
-         For more information see: https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/chrome/ChromeOptions.html */
+        /** ChomeOptions allows us to set browser-specific behavior such as profile settings, headless capabilities,
+         * insecure tls certs, etc.
+         * For additional options see: https://chromedriver.chromium.org/capabilities
+         * */
 
         ChromeOptions chromeOpts = new ChromeOptions();
-        chromeOpts.setExperimentalOption("w3c", true);
+        chromeOpts.addArguments("user-data-dir=/path/to/your/custom/profile");
 
-        /** The MutableCapabilities class  came into existence with Selenium 3.6.0 and acts as the parent class for
-         all browser implementations--including the ChromeOptions class extension.
-         Fore more information see: https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/MutableCapabilities.html */
+        /** The MutableCapabilities class is now the superclass for handling all option & capabilities implementations,
+         * including Selenium Browser Options classes (like ChromeOptions),
+         * and is required for Sauce Labs specific configurations
+         * */
 
         MutableCapabilities sauceOpts = new MutableCapabilities();
         sauceOpts.setCapability("name", methodName);
-        sauceOpts.setCapability("build", "Java-W3C-Examples");
-        sauceOpts.setCapability("seleniumVersion", "3.141.59");
         sauceOpts.setCapability("username", username);
         sauceOpts.setCapability("accessKey", accessKey);
         sauceOpts.setCapability("tags", testInfo.getTags());
 
 
-        /** Below we see the use of our other capability objects, 'chromeOpts' and 'sauceOpts',
-         defined in ChromeOptions.CAPABILITY and sauce:options respectively.
+        /** DesiredCapabilities is no longer the recommended class to use, so to combine both ChromeOptions and
+         * Sauce Configuration values into a capabilities instance that can be sent to
+         * the RemoteWebDriver, MutableCapabilities should be used here as well.
+         * With this approach it makes sense to add the w3c compliant top-level parameters here as well
+         * For more information, see: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
          */
-        DesiredCapabilities caps = new DesiredCapabilities();
-        caps.setCapability(ChromeOptions.CAPABILITY,  chromeOpts);
+
+        MutableCapabilities caps = new MutableCapabilities();
+        caps.setCapability("goog:chromeOptions",  chromeOpts);
         caps.setCapability("sauce:options", sauceOpts);
-        caps.setCapability("browserName", "googlechrome");
+        caps.setCapability("browserName", "chrome");
         caps.setCapability("browserVersion", "latest");
         caps.setCapability("platformName", "windows 10");
 
         /** Finally, we pass our DesiredCapabilities object 'caps' as a parameter of our RemoteWebDriver instance */
-        String sauceUrl = "https://ondemand.saucelabs.com:443/wd/hub";
+        String sauceUrl = "https://ondemand.us-west-1.saucelabs.com/wd/hub";
         URL url = new URL(sauceUrl);
         driver = new RemoteWebDriver(url, caps);
     }

--- a/w3c-examples/w3c-junit5/src/test/java/JUnit5W3CChromeTest.java
+++ b/w3c-examples/w3c-junit5/src/test/java/JUnit5W3CChromeTest.java
@@ -32,18 +32,11 @@ public class JUnit5W3CChromeTest {
         String accessKey = System.getenv("SAUCE_ACCESS_KEY");
         String methodName = testInfo.getDisplayName();
 
-        /** ChomeOptions allows us to set browser-specific behavior such as profile settings, headless capabilities,
-         * insecure tls certs, etc.
-         * For additional options see: https://chromedriver.chromium.org/capabilities
-         * */
-
-        ChromeOptions chromeOpts = new ChromeOptions();
-        chromeOpts.addArguments("user-data-dir=/path/to/your/custom/profile");
-
         /** The MutableCapabilities class is now the superclass for handling all option & capabilities implementations,
          * including Selenium Browser Options classes (like ChromeOptions),
          * and is required for Sauce Labs specific configurations
-         * */
+         * For available options, see: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+         */
 
         MutableCapabilities sauceOpts = new MutableCapabilities();
         sauceOpts.setCapability("name", methodName);
@@ -52,24 +45,29 @@ public class JUnit5W3CChromeTest {
         sauceOpts.setCapability("tags", testInfo.getTags());
 
 
-        /** DesiredCapabilities is no longer the recommended class to use, so to combine both ChromeOptions and
-         * Sauce Configuration values into a capabilities instance that can be sent to
-         * the RemoteWebDriver, MutableCapabilities should be used here as well.
-         * With this approach it makes sense to add the w3c compliant top-level parameters here as well
-         * For more information, see: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+        /** DesiredCapabilities is being deprecated in favor of using Browser Options classes for everything.
+         * Browser Options support both standard w3c values (https://w3c.github.io/webdriver/#capabilities)
+         * as well as browser-specific values (https://chromedriver.chromium.org/capabilities)
+         * including behavior such as profile settings, mobile emulation, headless capabilities, insecure tls certs, etc.
+         *
+         * Sauce Configuration values can be addded directly to the browser options class
          */
 
-        MutableCapabilities caps = new MutableCapabilities();
-        caps.setCapability("goog:chromeOptions",  chromeOpts);
-        caps.setCapability("sauce:options", sauceOpts);
-        caps.setCapability("browserName", "chrome");
-        caps.setCapability("browserVersion", "latest");
-        caps.setCapability("platformName", "windows 10");
+        ChromeOptions chromeOpts = new ChromeOptions();
+        chromeOpts.addArguments("user-data-dir=/path/to/your/custom/profile");
 
-        /** Finally, we pass our DesiredCapabilities object 'caps' as a parameter of our RemoteWebDriver instance */
+        chromeOpts.setCapability("browserName", "chrome");
+        chromeOpts.setCapability("browserVersion", "latest");
+        chromeOpts.setCapability("platformName", "windows 10");
+
+        chromeOpts.setCapability("sauce:options", sauceOpts);
+
+        /**
+         * Finally, we pass our Browser Options instance as a parameter of our RemoteWebDriver constructor
+         */
         String sauceUrl = "https://ondemand.us-west-1.saucelabs.com/wd/hub";
         URL url = new URL(sauceUrl);
-        driver = new RemoteWebDriver(url, caps);
+        driver = new RemoteWebDriver(url, chromeOpts);
     }
     /**
      * @Tag is a JUnit 5 annotation that defines test method tags that aid in reporting and filtering tests.

--- a/w3c-examples/w3c-junit5/src/test/java/JUnit5W3CFirefoxTest.java
+++ b/w3c-examples/w3c-junit5/src/test/java/JUnit5W3CFirefoxTest.java
@@ -33,18 +33,11 @@ public class JUnit5W3CFirefoxTest {
         String accessKey = System.getenv("SAUCE_ACCESS_KEY");
         String methodName = testInfo.getDisplayName();
 
-        /** FirefoxOptions allows us to set browser-specific behavior such as profile settings, headless capabilities,
-         * log levels, etc.
-         * For additional options see: https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions
-         * */
-
-        FirefoxOptions foxOpts = new FirefoxOptions();
-        foxOpts.setLogLevel(FirefoxDriverLogLevel.DEBUG);
-
         /** The MutableCapabilities class is now the superclass for handling all option & capabilities implementations,
          * including Selenium Browser Options classes (like FirefoxOptions),
          * and is required for Sauce Labs specific configurations
-         * */
+         * For available options, see: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+         */
 
         MutableCapabilities sauceOpts = new MutableCapabilities();
         sauceOpts.setCapability("name", methodName);
@@ -52,25 +45,29 @@ public class JUnit5W3CFirefoxTest {
         sauceOpts.setCapability("accessKey", accessKey);
         sauceOpts.setCapability("tags", testInfo.getTags());
 
-
-        /** DesiredCapabilities is no longer the recommended class to use, so to combine both FirefoxOptions and
-         * Sauce Configuration values into a capabilities instance that can be sent to
-         * the RemoteWebDriver, MutableCapabilities should be used here as well.
-         * With this approach it makes sense to add the w3c compliant top-level parameters here as well
-         * For more information, see: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+        /** DesiredCapabilities is being deprecated in favor of using Browser Options classes for everything.
+         * Browser Options support both standard w3c values (https://w3c.github.io/webdriver/#capabilities)
+         * as well as browser-specific values (https://firefoxdriver.chromium.org/capabilities)
+         * including behavior such as profile settings, mobile emulation, headless capabilities, insecure tls certs, etc.
+         *
+         * Sauce Configuration values can be addded directly to the browser options class
          */
 
-        MutableCapabilities caps = new MutableCapabilities();
-        caps.setCapability("moz:firefoxOptions",  foxOpts);
-        caps.setCapability("sauce:options", sauceOpts);
-        caps.setCapability("browserName", "firefox");
-        caps.setCapability("browserVersion", "latest");
-        caps.setCapability("platformName", "windows 10");
+        FirefoxOptions firefoxOpts = new FirefoxOptions();
+        firefoxOpts.setLogLevel(FirefoxDriverLogLevel.DEBUG);
 
-        /** Finally, we pass our DesiredCapabilities object 'caps' as a parameter of our RemoteWebDriver instance */
+        firefoxOpts.setCapability("browserName", "firefox");
+        firefoxOpts.setCapability("browserVersion", "latest");
+        firefoxOpts.setCapability("platformName", "windows 10");
+
+        firefoxOpts.setCapability("sauce:options", sauceOpts);
+
+        /**
+         * Finally, we pass our Browser Options instance as a parameter of our RemoteWebDriver constructor
+         */
         String sauceUrl = "https://ondemand.us-west-1.saucelabs.com/wd/hub";
         URL url = new URL(sauceUrl);
-        driver = new RemoteWebDriver(url, caps);
+        driver = new RemoteWebDriver(url, firefoxOpts);
     }
     /**
      * @Tag is a JUnit 5 annotation that defines test method tags that aid in reporting and filtering tests.
@@ -83,7 +80,7 @@ public class JUnit5W3CFirefoxTest {
     For more information visit the docs: https://junit.org/junit5/docs/5.0.2/api/org/junit/jupiter/api/DisplayName.html
 
      */
-    @DisplayName("JUnit5W3CFirefoxTest()")
+    @DisplayName("Junit5W3CFirefoxTest()")
     /**
      * @Test is a JUnit 5 annotation that defines the actual test case, along with the test execution commands.
     In the example below we:
@@ -94,7 +91,7 @@ public class JUnit5W3CFirefoxTest {
     For more information visit the docs: https://junit.org/junit5/docs/5.0.2/api/org/junit/jupiter/api/Test.html
      */
     @Test
-    public void Junit5w3cFirefoxTest() throws AssertionError {
+    public void JUnit5w3cFirefoxTest() throws AssertionError {
         driver.navigate().to("https://www.saucedemo.com");
         String getTitle = driver.getTitle();
         Assertions.assertEquals(getTitle, "Swag Labs");

--- a/w3c-examples/w3c-junit5/src/test/java/JUnit5W3CFirefoxTest.java
+++ b/w3c-examples/w3c-junit5/src/test/java/JUnit5W3CFirefoxTest.java
@@ -2,8 +2,8 @@ import org.junit.jupiter.api.*;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.firefox.FirefoxDriverLogLevel;
 import org.openqa.selenium.firefox.FirefoxOptions;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
@@ -33,30 +33,34 @@ public class JUnit5W3CFirefoxTest {
         String accessKey = System.getenv("SAUCE_ACCESS_KEY");
         String methodName = testInfo.getDisplayName();
 
-        /** FirefoxOptions allows us to set browser-specific behavior such as profile settings, headless capabilities, insecure tls certs,
-         and in this example--the W3C protocol
-         For more information see: https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/firefox/FirefoxOptions.html */
+        /** FirefoxOptions allows us to set browser-specific behavior such as profile settings, headless capabilities,
+         * log levels, etc.
+         * For additional options see: https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions
+         * */
 
         FirefoxOptions foxOpts = new FirefoxOptions();
-        foxOpts.setCapability("w3c", true);
+        foxOpts.setLogLevel(FirefoxDriverLogLevel.DEBUG);
 
-        /** The MutableCapabilities class  came into existence with Selenium 3.6.0 and acts as the parent class for
-         all browser implementations--including the FirefoxOptions class extension.
-         Fore more information see: https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/MutableCapabilities.html */
+        /** The MutableCapabilities class is now the superclass for handling all option & capabilities implementations,
+         * including Selenium Browser Options classes (like FirefoxOptions),
+         * and is required for Sauce Labs specific configurations
+         * */
 
         MutableCapabilities sauceOpts = new MutableCapabilities();
         sauceOpts.setCapability("name", methodName);
-        sauceOpts.setCapability("build", "Java-W3C-Examples");
-        sauceOpts.setCapability("seleniumVersion", "3.141.59");
         sauceOpts.setCapability("username", username);
         sauceOpts.setCapability("accessKey", accessKey);
         sauceOpts.setCapability("tags", testInfo.getTags());
 
 
-        /** Below we see the use of our other capability objects, 'foxOpts' and 'sauceOpts',
-         defined in 'moz:firefoxOptions' and sauce:options respectively.
+        /** DesiredCapabilities is no longer the recommended class to use, so to combine both FirefoxOptions and
+         * Sauce Configuration values into a capabilities instance that can be sent to
+         * the RemoteWebDriver, MutableCapabilities should be used here as well.
+         * With this approach it makes sense to add the w3c compliant top-level parameters here as well
+         * For more information, see: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
          */
-        DesiredCapabilities caps = new DesiredCapabilities();
+
+        MutableCapabilities caps = new MutableCapabilities();
         caps.setCapability("moz:firefoxOptions",  foxOpts);
         caps.setCapability("sauce:options", sauceOpts);
         caps.setCapability("browserName", "firefox");
@@ -64,7 +68,7 @@ public class JUnit5W3CFirefoxTest {
         caps.setCapability("platformName", "windows 10");
 
         /** Finally, we pass our DesiredCapabilities object 'caps' as a parameter of our RemoteWebDriver instance */
-        String sauceUrl = "https://ondemand.saucelabs.com:443/wd/hub";
+        String sauceUrl = "https://ondemand.us-west-1.saucelabs.com/wd/hub";
         URL url = new URL(sauceUrl);
         driver = new RemoteWebDriver(url, caps);
     }

--- a/w3c-examples/w3c-testng/src/test/java/TestNGW3CChromeTest.java
+++ b/w3c-examples/w3c-testng/src/test/java/TestNGW3CChromeTest.java
@@ -35,18 +35,11 @@ public class TestNGW3CChromeTest {
         String accessKey = System.getenv("SAUCE_ACCESS_KEY");
         String methodName = method.getName();
 
-        /** ChomeOptions allows us to set browser-specific behavior such as profile settings, headless capabilities,
-         * insecure tls certs, etc.
-         * For additional options see: https://chromedriver.chromium.org/capabilities
-         * */
-
-        ChromeOptions chromeOpts = new ChromeOptions();
-        chromeOpts.addArguments("user-data-dir=/path/to/your/custom/profile");
-
         /** The MutableCapabilities class is now the superclass for handling all option & capabilities implementations,
          * including Selenium Browser Options classes (like ChromeOptions),
          * and is required for Sauce Labs specific configurations
-         * */
+         * For available options, see: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+         */
 
         MutableCapabilities sauceOpts = new MutableCapabilities();
         sauceOpts.setCapability("name", methodName);
@@ -54,24 +47,29 @@ public class TestNGW3CChromeTest {
         sauceOpts.setCapability("accessKey", accessKey);
         sauceOpts.setCapability("tags", "w3c-chrome-tests");
 
-        /** DesiredCapabilities is no longer the recommended class to use, so to combine both ChromeOptions and
-         * Sauce Configuration values into a capabilities instance that can be sent to
-         * the RemoteWebDriver, MutableCapabilities should be used here as well.
-         * With this approach it makes sense to add the w3c compliant top-level parameters here as well
-         * For more information, see: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+        /** DesiredCapabilities is being deprecated in favor of using Browser Options classes for everything.
+         * Browser Options support both standard w3c values (https://w3c.github.io/webdriver/#capabilities)
+         * as well as browser-specific values (https://chromedriver.chromium.org/capabilities)
+         * including behavior such as profile settings, mobile emulation, headless capabilities, insecure tls certs, etc.
+         *
+         * Sauce Configuration values can be addded directly to the browser options class
          */
 
-        MutableCapabilities caps = new MutableCapabilities();
-        caps.setCapability("goog:chromeOptions",  chromeOpts);
-        caps.setCapability("sauce:options", sauceOpts);
-        caps.setCapability("browserName", "googlechrome");
-        caps.setCapability("browserVersion", "latest");
-        caps.setCapability("platformName", "windows 10");
+        ChromeOptions chromeOpts = new ChromeOptions();
+        chromeOpts.addArguments("user-data-dir=/path/to/your/custom/profile");
 
-        /** Finally, we pass our DesiredCapabilities object 'caps' as a parameter of our RemoteWebDriver instance */
+        chromeOpts.setCapability("browserName", "googlechrome");
+        chromeOpts.setCapability("browserVersion", "latest");
+        chromeOpts.setCapability("platformName", "windows 10");
+
+        chromeOpts.setCapability("sauce:options", sauceOpts);
+
+        /**
+         * Finally, we pass our Browser Options instance as a parameter of our RemoteWebDriver constructor
+        */
         String sauceUrl = "https://ondemand.us-west-1.saucelabs.com/wd/hub";
         URL url = new URL(sauceUrl);
-        driver = new RemoteWebDriver(url, caps);
+        driver = new RemoteWebDriver(url, chromeOpts);
     }
 
     /**

--- a/w3c-examples/w3c-testng/src/test/java/TestNGW3CChromeTest.java
+++ b/w3c-examples/w3c-testng/src/test/java/TestNGW3CChromeTest.java
@@ -2,7 +2,6 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testng.Assert;
 import org.testng.ITestResult;
@@ -36,37 +35,41 @@ public class TestNGW3CChromeTest {
         String accessKey = System.getenv("SAUCE_ACCESS_KEY");
         String methodName = method.getName();
 
-        /** ChomeOptions allows us to set browser-specific behavior such as profile settings, headless capabilities, insecure tls certs,
-         and in this example--the W3C protocol
-         For more information see: https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/chrome/ChromeOptions.html */
+        /** ChomeOptions allows us to set browser-specific behavior such as profile settings, headless capabilities,
+         * insecure tls certs, etc.
+         * For additional options see: https://chromedriver.chromium.org/capabilities
+         * */
 
         ChromeOptions chromeOpts = new ChromeOptions();
-        chromeOpts.setExperimentalOption("w3c", true);
+        chromeOpts.addArguments("user-data-dir=/path/to/your/custom/profile");
 
-        /** The MutableCapabilities class  came into existence with Selenium 3.6.0 and acts as the parent class for
-         all browser implementations--including the ChromeOptions class extension.
-         Fore more information see: https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/MutableCapabilities.html */
+        /** The MutableCapabilities class is now the superclass for handling all option & capabilities implementations,
+         * including Selenium Browser Options classes (like ChromeOptions),
+         * and is required for Sauce Labs specific configurations
+         * */
 
         MutableCapabilities sauceOpts = new MutableCapabilities();
         sauceOpts.setCapability("name", methodName);
-        sauceOpts.setCapability("build", "Java-W3C-Examples");
-        sauceOpts.setCapability("seleniumVersion", "3.141.59");
         sauceOpts.setCapability("username", username);
         sauceOpts.setCapability("accessKey", accessKey);
         sauceOpts.setCapability("tags", "w3c-chrome-tests");
 
-        /** Below we see the use of our other capability objects, 'chromeOpts' and 'sauceOpts',
-         defined in ChromeOptions.CAPABILITY and sauce:options respectively.
+        /** DesiredCapabilities is no longer the recommended class to use, so to combine both ChromeOptions and
+         * Sauce Configuration values into a capabilities instance that can be sent to
+         * the RemoteWebDriver, MutableCapabilities should be used here as well.
+         * With this approach it makes sense to add the w3c compliant top-level parameters here as well
+         * For more information, see: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
          */
-        DesiredCapabilities caps = new DesiredCapabilities();
-        caps.setCapability(ChromeOptions.CAPABILITY,  chromeOpts);
+
+        MutableCapabilities caps = new MutableCapabilities();
+        caps.setCapability("goog:chromeOptions",  chromeOpts);
         caps.setCapability("sauce:options", sauceOpts);
         caps.setCapability("browserName", "googlechrome");
         caps.setCapability("browserVersion", "latest");
         caps.setCapability("platformName", "windows 10");
 
         /** Finally, we pass our DesiredCapabilities object 'caps' as a parameter of our RemoteWebDriver instance */
-        String sauceUrl = "https://ondemand.saucelabs.com:443/wd/hub";
+        String sauceUrl = "https://ondemand.us-west-1.saucelabs.com/wd/hub";
         URL url = new URL(sauceUrl);
         driver = new RemoteWebDriver(url, caps);
     }

--- a/w3c-examples/w3c-testng/src/test/java/TestNGW3CFirefoxTest.java
+++ b/w3c-examples/w3c-testng/src/test/java/TestNGW3CFirefoxTest.java
@@ -36,18 +36,11 @@ public class TestNGW3CFirefoxTest {
         String accessKey = System.getenv("SAUCE_ACCESS_KEY");
         String methodName = method.getName();
 
-        /** FirefoxOptions allows us to set browser-specific behavior such as profile settings, headless capabilities,
-         * log levels, etc.
-         * For additional options see: https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions
-         * */
-
-        FirefoxOptions foxOpts = new FirefoxOptions();
-        foxOpts.setLogLevel(FirefoxDriverLogLevel.DEBUG);
-
         /** The MutableCapabilities class is now the superclass for handling all option & capabilities implementations,
          * including Selenium Browser Options classes (like FirefoxOptions),
          * and is required for Sauce Labs specific configurations
-         * */
+         * For available options, see: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+         */
 
         MutableCapabilities sauceOpts = new MutableCapabilities();
         sauceOpts.setCapability("name", methodName);
@@ -55,24 +48,29 @@ public class TestNGW3CFirefoxTest {
         sauceOpts.setCapability("accessKey", accessKey);
         sauceOpts.setCapability("tags", "w3c-chrome-tests");
 
-        /** DesiredCapabilities is no longer the recommended class to use, so to combine both FirefoxOptions and
-         * Sauce Configuration values into a capabilities instance that can be sent to
-         * the RemoteWebDriver, MutableCapabilities should be used here as well.
-         * With this approach it makes sense to add the w3c compliant top-level parameters here as well
-         * For more information, see: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+        /** DesiredCapabilities is being deprecated in favor of using Browser Options classes for everything.
+         * Browser Options support both standard w3c values (https://w3c.github.io/webdriver/#capabilities)
+         * as well as browser-specific values (https://firefoxdriver.chromium.org/capabilities)
+         * including behavior such as profile settings, mobile emulation, headless capabilities, insecure tls certs, etc.
+         *
+         * Sauce Configuration values can be addded directly to the browser options class
          */
 
-        MutableCapabilities caps = new MutableCapabilities();
-        caps.setCapability("moz:firefoxOptions",  foxOpts);
-        caps.setCapability("sauce:options", sauceOpts);
-        caps.setCapability("browserName", "firefox");
-        caps.setCapability("browserVersion", "latest");
-        caps.setCapability("platformName", "windows 10");
+        FirefoxOptions firefoxOpts = new FirefoxOptions();
+        firefoxOpts.setLogLevel(FirefoxDriverLogLevel.DEBUG);
 
-        /** Finally, we pass our DesiredCapabilities object 'caps' as a parameter of our RemoteWebDriver instance */
+        firefoxOpts.setCapability("browserName", "firefox");
+        firefoxOpts.setCapability("browserVersion", "latest");
+        firefoxOpts.setCapability("platformName", "windows 10");
+
+        firefoxOpts.setCapability("sauce:options", sauceOpts);
+
+        /**
+         * Finally, we pass our Browser Options instance as a parameter of our RemoteWebDriver constructor
+         */
         String sauceUrl = "https://ondemand.us-west-1.saucelabs.com/wd/hub";
         URL url = new URL(sauceUrl);
-        driver = new RemoteWebDriver(url, caps);
+        driver = new RemoteWebDriver(url, firefoxOpts);
     }
 
     /**

--- a/w3c-examples/w3c-testng/src/test/java/TestNGW3CFirefoxTest.java
+++ b/w3c-examples/w3c-testng/src/test/java/TestNGW3CFirefoxTest.java
@@ -1,8 +1,8 @@
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.firefox.FirefoxDriverLogLevel;
 import org.openqa.selenium.firefox.FirefoxOptions;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testng.Assert;
 import org.testng.ITestResult;
@@ -36,29 +36,33 @@ public class TestNGW3CFirefoxTest {
         String accessKey = System.getenv("SAUCE_ACCESS_KEY");
         String methodName = method.getName();
 
-        /** FirefoxOptions allows us to set browser-specific behavior such as profile settings, headless capabilities, insecure tls certs,
-         and in this example--the W3C protocol
-         For more information see: https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/firefox/FirefoxOptions.html */
+        /** FirefoxOptions allows us to set browser-specific behavior such as profile settings, headless capabilities,
+         * log levels, etc.
+         * For additional options see: https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions
+         * */
 
         FirefoxOptions foxOpts = new FirefoxOptions();
-        foxOpts.setCapability("w3c", true);
+        foxOpts.setLogLevel(FirefoxDriverLogLevel.DEBUG);
 
-        /** The MutableCapabilities class  came into existence with Selenium 3.6.0 and acts as the parent class for
-         all browser implementations--including the FirefoxOptions class extension.
-         Fore more information see: https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/MutableCapabilities.html */
+        /** The MutableCapabilities class is now the superclass for handling all option & capabilities implementations,
+         * including Selenium Browser Options classes (like FirefoxOptions),
+         * and is required for Sauce Labs specific configurations
+         * */
 
         MutableCapabilities sauceOpts = new MutableCapabilities();
         sauceOpts.setCapability("name", methodName);
-        sauceOpts.setCapability("build", "Java-W3C-Examples");
-        sauceOpts.setCapability("seleniumVersion", "3.141.59");
         sauceOpts.setCapability("username", username);
         sauceOpts.setCapability("accessKey", accessKey);
         sauceOpts.setCapability("tags", "w3c-chrome-tests");
 
-        /** Below we see the use of our other capability objects, 'foxOpts' and 'sauceOpts',
-         defined in 'moz:firefoxOptions' and sauce:options respectively.
+        /** DesiredCapabilities is no longer the recommended class to use, so to combine both FirefoxOptions and
+         * Sauce Configuration values into a capabilities instance that can be sent to
+         * the RemoteWebDriver, MutableCapabilities should be used here as well.
+         * With this approach it makes sense to add the w3c compliant top-level parameters here as well
+         * For more information, see: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
          */
-        DesiredCapabilities caps = new DesiredCapabilities();
+
+        MutableCapabilities caps = new MutableCapabilities();
         caps.setCapability("moz:firefoxOptions",  foxOpts);
         caps.setCapability("sauce:options", sauceOpts);
         caps.setCapability("browserName", "firefox");
@@ -66,7 +70,7 @@ public class TestNGW3CFirefoxTest {
         caps.setCapability("platformName", "windows 10");
 
         /** Finally, we pass our DesiredCapabilities object 'caps' as a parameter of our RemoteWebDriver instance */
-        String sauceUrl = "https://ondemand.saucelabs.com:443/wd/hub";
+        String sauceUrl = "https://ondemand.us-west-1.saucelabs.com/wd/hub";
         URL url = new URL(sauceUrl);
         driver = new RemoteWebDriver(url, caps);
     }


### PR DESCRIPTION
My proposed updates for the code we should be encouraging users to use (if they aren't using Sauce Bindings).

1. Updated ondemand URL
2. Using MutableCapabilities instead of DesiredCapabilities
3. Removing w3c: true which we ignore anyway now
4. Updated Reference URLs

Edit:
5. Updated code to only use MutableCapabilities for Sauce configs