### PR TITLE
Maven Surefire Global Variable

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -24,4 +24,4 @@ jobs:
       env:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-      run: mvn test -pl best-practice -Dtest=DesktopTests#loginWorks
+      run: mvn test -pl best-practice -Dtest=DesktopTests

--- a/appium-examples/pom.xml
+++ b/appium-examples/pom.xml
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>${maven.surefire.version}</version>
                 <configuration>
                     <parallel>all</parallel>
                     <threadCountMethods>30</threadCountMethods>

--- a/best-practice/pom.xml
+++ b/best-practice/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>${maven.surefire.version}</version>
                 <configuration>
                     <parallel>all</parallel>
                     <threadCountMethods>100</threadCountMethods>

--- a/on-boarding-modules/junit/pom.xml
+++ b/on-boarding-modules/junit/pom.xml
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>${maven.surefire.version}</version>
                 <configuration>
                     <!-- CircleCI build workaround -->
                     <argLine>-Xms1024m -Xmx2048m</argLine>

--- a/on-boarding-modules/testng/pom.xml
+++ b/on-boarding-modules/testng/pom.xml
@@ -43,7 +43,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
+                <version>${maven.surefire.version}</version>
                 <configuration>
                     <!-- CircleCI build workaround -->
                     <argLine>-Xms1024m -Xmx2048m</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <selenium.version>3.141.59</selenium.version>
         <sauce.version>1.0.2</sauce.version>
         <appium.version>7.3.0</appium.version>
-        <maven.surefire.version>2.22.1</maven.surefire.version>
+        <maven.surefire.version>3.0.0-M4</maven.surefire.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <selenium.version>3.141.59</selenium.version>
         <sauce.version>1.0.2</sauce.version>
         <appium.version>7.3.0</appium.version>
-        <maven.surefire.version>3.0.0-M5</maven.surefire.version>
+        <maven.surefire.version>2.22.1</maven.surefire.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <selenium.version>3.141.59</selenium.version>
         <sauce.version>1.0.2</sauce.version>
         <appium.version>7.3.0</appium.version>
+        <maven.surefire.version>3.0.0-M5</maven.surefire.version>
     </properties>
 
     <modules>
@@ -88,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>${maven.surefire.version}</version>
                 <configuration>
                     <parallel>classes</parallel>
                     <threadCountMethods>100</threadCountMethods>

--- a/selenium-cucumber-examples/cucumber/pom.xml
+++ b/selenium-cucumber-examples/cucumber/pom.xml
@@ -76,7 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>${maven.surefire.version}</version>
                 <configuration>
                     <forkCount>6</forkCount>
                     <reuseForks>false</reuseForks>

--- a/selenium-examples/pom.xml
+++ b/selenium-examples/pom.xml
@@ -35,7 +35,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M4</version>
+                <version>${maven.surefire.version}</version>
                 <configuration>
                     <properties>
                         <configurationParameters>

--- a/selenium-junit4-examples/pom.xml
+++ b/selenium-junit4-examples/pom.xml
@@ -21,7 +21,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>${maven.surefire.version}</version>
                 <configuration>
                     <parallel>all</parallel>
                     <threadCountMethods>100</threadCountMethods>

--- a/selenium-testng-examples/pom.xml
+++ b/selenium-testng-examples/pom.xml
@@ -29,7 +29,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
+                <version>${maven.surefire.version}</version>
                 <configuration>
                     <parallel>methods</parallel>
                     <threadCount>10</threadCount>

--- a/w3c-examples/w3c-testng/pom.xml
+++ b/w3c-examples/w3c-testng/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
+                <version>${maven.surefire.version}</version>
                 <configuration>
                     <!-- CircleCI build workaround -->
                     <argLine>-Xms1024m -Xmx2048m</argLine>


### PR DESCRIPTION
Added a maven.surefire.version variable so that it can be used in
all of the pom.xml files to keep them aligned for future. Updated
maven surefire plugin to latest version (2.22.1)

Fix an issue with github actions for DesktopTests that was causing
an issue with execution. Reverted back to calling DesktopTests
without a specific function until we figure out why using