### PR TITLE
Had to move the "cd" command before the maven commands to account for the missing parent pom file.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,9 +2,9 @@
 image: maven:3.8.6-jdk-11
 tasks:
   - name: Script Task
+    dir: gitpod
     init: |
       mvn dependency:resolve
       mvn test-compile
-      cd gitpod
-    command: $MVN_COMMAND
+    command: mvn clean test
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,5 +6,5 @@ tasks:
       cd gitpod
       mvn dependency:resolve
       mvn test-compile
-    command: mvn clean test
+    command: mvn clean compile
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,8 +2,8 @@
 image: maven:3.8.6-jdk-11
 tasks:
   - name: Script Task
-    dir: gitpod
     init: |
+      cd gitpod
       mvn dependency:resolve
       mvn test-compile
     command: mvn clean test


### PR DESCRIPTION
- explicitly spelling out the mvn command, since I couldn't figure out how the $MVN_COMMAND variable was being set
- changing the mvn command to compile the code, rather than run tests. We can't run tests until the credentials have been set, which can't be done without the user giving some input.